### PR TITLE
fix logrus package name

### DIFF
--- a/inforus.go
+++ b/inforus.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"sync"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 // Skip the following 3 frames.

--- a/inforus.go
+++ b/inforus.go
@@ -59,7 +59,7 @@ func (h Hook) Fire(entry *log.Entry) error {
 	for i := 0; i < cnt; i++ {
 		fu := runtime.FuncForPC(pc[i])
 		name := fu.Name()
-		if !strings.Contains(name, "github.com/Sirupsen/logrus") {
+		if !strings.Contains(name, "github.com/sirupsen/logrus") {
 			file, line := fu.FileLine(pc[i] - 1)
 			if h.file {
 				h.mu.Lock()


### PR DESCRIPTION
Changes the logrus package name to lowercase according to the official
logrus docs:

> Everything using logrus will need to use the lower-case: github.com/sirupsen/logrus. Any package that isn't, should be changed.

Closes #2 